### PR TITLE
mainnet_v1: add migration command for SMT trie feature

### DIFF
--- a/mainnet_v1/docker-compose.yml
+++ b/mainnet_v1/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     - RUST_LOG=info
     command: |
       bash -c 'set -ex
+        # migrate command for SMT trie feature, only needs to be run on first activation
+        godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
+
         # use this command to rewind the chain to the last valid block, if the node has encountered
         # some bad blocks accidentally due to e.g. version/configuration differences.
         # see also: https://github.com/godwokenrises/godwoken/pull/832


### PR DESCRIPTION
## Note
The image `ghcr.io/godwokenrises/godwoken:v1.14.0-smt-trie` will enable SMT-trie feature, which **will greatly decrease the amount of store read/write operations needed to update SMTs, thus improving transaction throughput and block syncing speed**. SMT roots and proofs won't change.

To enable SMT-trie feature, data migration for `gw-readonly-node` is required for this upgrade.
```bash
  # gw-readonly-node
  # migrate command for SMT trie feature, only needs to be run on first activation
  godwoken migrate --config /deploy/config.toml | tee -a /mnt/smt-migrate.log
``` 